### PR TITLE
TLS client verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,24 @@ EBI to access the data through `local_ega_ebi`.
 
 The following environment variables can be used to configure the database:
 
-| Variable | Description | Default value |
-|---------:|:------------|:--------------|
-| PGDATA | The data directory | `/ega/data` |
-| DB\_LEGA\_IN\_PASSWORD  | `lega_in`'s password | - |
-| DB\_LEGA\_OUT\_PASSWORD  | `lega_out`'s password | - |
-| TZ | Timezone for the Postgres server | Europe/Madrid |
+| Variable                | Description                      | Default value |
+|------------------------:|:---------------------------------|:--------------|
+| PGDATA                  | The data directory               | `/ega/data`   |
+| DB\_LEGA\_IN\_PASSWORD  | `lega_in`'s password             | -             |
+| DB\_LEGA\_OUT\_PASSWORD | `lega_out`'s password            | -             |
+| TZ                      | Timezone for the Postgres server | Europe/Madrid |
 
 ## TLS support
 
-| Variable | Description | Default value |
-|---------:|:------------|:--------------|
-| PG\_CERTFILE   | Public Certificate in PEM format    | `/etc/ega/pg.cert` |
-| PG\_KEYFILE    | Private Key in PEM format           | `/etc/ega/pg.key`  |
-| PG\_CACERTFILE | Public CA Certificate in PEM format | `/etc/ega/CA.cert` |
-| PG\_VERIFY\_PEER | Enforce client verification       | 1 |
-| SSL\_SUBJ | Subject for the self-signed certificate creation | `/C=ES/ST=Spain/L=Barcelona/O=CRG/OU=SysDevs/CN=LocalEGA/emailAddress=all.ega@crg.eu` |
+| Variable         | Description                                      | Default value      |
+|-----------------:|:-------------------------------------------------|:-------------------|
+| PG\_CERTFILE     | Public Certificate in PEM format                 | `/etc/ega/pg.cert` |
+| PG\_KEYFILE      | Private Key in PEM format                        | `/etc/ega/pg.key`  |
+| PG\_CACERTFILE   | Public CA Certificate in PEM format              | `/etc/ega/CA.cert` |
+| PG\_VERIFY\_PEER | Enforce client verification                      | 1                  |
+| SSL\_SUBJ        | Subject for the self-signed certificate creation | `/C=ES/ST=Spain/L=Barcelona/O=CRG/OU=SysDevs/CN=LocalEGA/emailAddress=all.ega@crg.eu` |
 
-If not already injected, the files located at `PG\_CERTFILE` and `PG\_KEYFILE` will be generated, as a self-signed public/private certificate pair, using `SSL_SUBJ`
+If not already injected, the files located at `PG_CERTFILE` and `PG_KEYFILE` will be generated, as a self-signed public/private certificate pair, using `SSL_SUBJ`.
 
-If `PG\_CACERTFILE` exists and `PG\_VERIFY\_PEER` is set to `1`, client verification is enforced.
+If `PG_CACERTFILE` exists and `PG_VERIFY_PEER` is set to `1`, client verification is enforced.
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ We use
 [Postgres 11.2](https://github.com/docker-library/postgres/tree/6c3b27f1433ad81675afb386a182098dc867e3e8/11/alpine)
 and Alpine 3.9.
 
-The entrypoint creates a self-signed certificate in `/etc/ega/pg.cert`
-and the associated private key in `/etc/ega/pg.key`.
-
 Security is hardened:
 - We do not use 'trust' even for local connections
 - Requiring password authentication for all
 - Using scram-sha-256 is stronger than md5
-- Enforcing SSL communication
+- Enforcing TLS communication
+- Enforcing client-certificate verification
+
+## Configuration
 
 There are 2 users (`lega_in` and `lega_out`), and 2 schemas
 (`local_ega` and `local_ega_download`).  A special one is included for
@@ -24,5 +24,19 @@ The following environment variables can be used to configure the database:
 | PGDATA | The data directory | `/ega/data` |
 | DB\_LEGA\_IN\_PASSWORD  | `lega_in`'s password | - |
 | DB\_LEGA\_OUT\_PASSWORD  | `lega_out`'s password | - |
-| SSL\_SUBJ | Subject for the self-signed certificate creation | `/C=ES/ST=Spain/L=Barcelona/O=CRG/OU=SysDevs/CN=LocalEGA/emailAddress=all.ega@crg.eu` |
 | TZ | Timezone for the Postgres server | Europe/Madrid |
+
+## TLS support
+
+| Variable | Description | Default value |
+|---------:|:------------|:--------------|
+| PG\_CERTFILE   | Public Certificate in PEM format    | `/etc/ega/pg.cert` |
+| PG\_KEYFILE    | Private Key in PEM format           | `/etc/ega/pg.key`  |
+| PG\_CACERTFILE | Public CA Certificate in PEM format | `/etc/ega/CA.cert` |
+| PG\_VERIFY\_PEER | Enforce client verification       | 1 |
+| SSL\_SUBJ | Subject for the self-signed certificate creation | `/C=ES/ST=Spain/L=Barcelona/O=CRG/OU=SysDevs/CN=LocalEGA/emailAddress=all.ega@crg.eu` |
+
+If not already injected, the files located at `PG\_CERTFILE` and `PG\_KEYFILE` will be generated, as a self-signed public/private certificate pair, using `SSL_SUBJ`
+
+If `PG\_CACERTFILE` exists and `PG\_VERIFY\_PEER` is set to `1`, client verification is enforced.
+

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ The following environment variables can be used to configure the database:
 
 | Variable         | Description                                      | Default value      |
 |-----------------:|:-------------------------------------------------|:-------------------|
-| PG\_CERTFILE     | Public Certificate in PEM format                 | `/etc/ega/pg.cert` |
-| PG\_KEYFILE      | Private Key in PEM format                        | `/etc/ega/pg.key`  |
-| PG\_CACERTFILE   | Public CA Certificate in PEM format              | `/etc/ega/CA.cert` |
+| PG\_SERVER\_CERT | Public Certificate in PEM format                 | `/etc/ega/pg.cert` |
+| PG\_SERVER\_KEY  | Private Key in PEM format                        | `/etc/ega/pg.key`  |
+| PG\_CA           | Public CA Certificate in PEM format              | `/etc/ega/CA.cert` |
 | PG\_VERIFY\_PEER | Enforce client verification                      | 0                  |
 | SSL\_SUBJ        | Subject for the self-signed certificate creation | `/C=ES/ST=Spain/L=Barcelona/O=CRG/OU=SysDevs/CN=LocalEGA/emailAddress=all.ega@crg.eu` |
 
-If not already injected, the files located at `PG_CERTFILE` and `PG_KEYFILE` will be generated, as a self-signed public/private certificate pair, using `SSL_SUBJ`.
+If not already injected, the files located at `PG_SERVER_CERT` and `PG_SERVER_KEY` will be generated, as a self-signed public/private certificate pair, using `SSL_SUBJ`.
 
-Client verification is enforced if and only if `PG_CACERTFILE` exists and `PG_VERIFY_PEER` is set to `1`.
+Client verification is enforced if and only if `PG_CA` exists and `PG_VERIFY_PEER` is set to `1`.
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ The following environment variables can be used to configure the database:
 | PG\_CERTFILE     | Public Certificate in PEM format                 | `/etc/ega/pg.cert` |
 | PG\_KEYFILE      | Private Key in PEM format                        | `/etc/ega/pg.key`  |
 | PG\_CACERTFILE   | Public CA Certificate in PEM format              | `/etc/ega/CA.cert` |
-| PG\_VERIFY\_PEER | Enforce client verification                      | 1                  |
+| PG\_VERIFY\_PEER | Enforce client verification                      | 0                  |
 | SSL\_SUBJ        | Subject for the self-signed certificate creation | `/C=ES/ST=Spain/L=Barcelona/O=CRG/OU=SysDevs/CN=LocalEGA/emailAddress=all.ega@crg.eu` |
 
 If not already injected, the files located at `PG_CERTFILE` and `PG_KEYFILE` will be generated, as a self-signed public/private certificate pair, using `SSL_SUBJ`.
 
-If `PG_CACERTFILE` exists and `PG_VERIFY_PEER` is set to `1`, client verification is enforced.
+Client verification is enforced if and only if `PG_CACERTFILE` exists and `PG_VERIFY_PEER` is set to `1`.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,7 +89,7 @@ local  	 all  	    all	      		     scram-sha-256
 hostssl  all 	    all       127.0.0.1/32   scram-sha-256
 hostssl  all  	    all       ::1/128        scram-sha-256
 # Note: For the moment, not very network-separated :-p
-hostssl  all  	    all       all            scram-sha-256
+hostssl  all  	    all       all            scram-sha-256   clientcert=1
 EOF
 
 echo

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ set -Eeo pipefail
 PG_CERTFILE=${PG_CERTFILE:-/etc/ega/pg.cert}
 PG_KEYFILE=${PG_KEYFILE:-/etc/ega/pg.key}
 PG_CACERTFILE=${PG_CACERTFILE:-/etc/ega/CA.cert}
-PG_VERIFY_PEER=${PG_VERIFY_PEER:-1}
+PG_VERIFY_PEER=${PG_VERIFY_PEER:-0}
 
 if [ "$(id -u)" = '0' ]; then
     # When root

--- a/pg.conf
+++ b/pg.conf
@@ -17,7 +17,7 @@ ssl = on
 
 ssl_cert_file = '/etc/ega/pg.cert'
 ssl_key_file = '/etc/ega/pg.key'
-#ssl_ca_file = ''			# (change requires restart)
+ssl_ca_file = '/etc/ega/CA.cert'
 #ssl_crl_file = ''			# (change requires restart)
 
 password_encryption = scram-sha-256

--- a/pg.conf
+++ b/pg.conf
@@ -15,9 +15,9 @@ ssl = on
 #ssl_prefer_server_ciphers = on		# (change requires restart)
 #ssl_ecdh_curve = 'prime256v1'		# (change requires restart)
 
-ssl_cert_file = '/etc/ega/pg.cert'
-ssl_key_file = '/etc/ega/pg.key'
-ssl_ca_file = '/etc/ega/CA.cert'
+#ssl_cert_file = '/etc/ega/pg.cert'
+#ssl_key_file = '/etc/ega/pg.key'
+#ssl_ca_file = '/etc/ega/CA.cert'
 #ssl_crl_file = ''			# (change requires restart)
 
 password_encryption = scram-sha-256


### PR DESCRIPTION
Client verification for connections using TLS.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [x] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Changes made:
certfile, keyfile, cacertfile and verify_peer are now parameters.

If certfile and keyfile do not exists, they will be generated (self-signed), so TLS is always enforced.
If verify_peer is set to `1`, and cacertfile exists, client verification is enforced too.

The file paths are not hard-coded.

### Related issues:
#4 
