### PR TITLE
Don't fail if chown or chmod doesn't work

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,8 +25,8 @@ if [ "$(id -u)" = '0' ]; then
 	echo "Using the injected certificate/privatekey pair" 
     fi
     # Fixing the ownership and permissions
-    chown postgres:postgres "${PG_SERVER_KEY}" "${PG_SERVER_CERT}"
-    chmod 600 "${PG_SERVER_KEY}"
+    chown postgres:postgres "${PG_SERVER_KEY}" "${PG_SERVER_CERT}" || true
+    chmod 600 "${PG_SERVER_KEY}" || true
 
     chown postgres:postgres /etc/ega/pg.conf
     

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,14 @@ if [ "$(id -u)" = '0' ]; then
     fi
     # Fixing the ownership and permissions
     chown postgres:postgres "${PG_SERVER_KEY}" "${PG_SERVER_CERT}" || true
-    chmod 600 "${PG_SERVER_KEY}" || true
+    for file in "$PG_SERVER_KEY" "$PG_SERVER_CERT"; do
+        if [ $(stat -c %U:%G "$file" ) != "postgres:postgres" ]; then
+            chown postgres:postgres "$file"
+        fi
+        if [ $(stat -c %a "$file") != "600" ]; then
+            chmod 600 "$file"
+        fi
+    done
 
     chown postgres:postgres /etc/ega/pg.conf
     

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,6 @@ if [ "$(id -u)" = '0' ]; then
 	echo "Using the injected certificate/privatekey pair" 
     fi
     # Fixing the ownership and permissions
-    chown postgres:postgres "${PG_SERVER_KEY}" "${PG_SERVER_CERT}" || true
     for file in "$PG_SERVER_KEY" "$PG_SERVER_CERT"; do
         if [ $(stat -c %U:%G "$file" ) != "postgres:postgres" ]; then
             chown postgres:postgres "$file"


### PR DESCRIPTION
In Docker Swarm, these files are injected as read-only configs, so `chown` and `chmod` fail.

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Use `|| true` to not fail.
