### PR TITLE
Adjusting for read-only injected files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,10 @@ if [ "$(id -u)" = '0' ]; then
 	echo "Using the injected certificate/privatekey pair" 
     fi
     # Fixing the ownership and permissions
+    cp "${PG_SERVER_KEY}" "${PG_SERVER_KEY}.lega"
+    PG_SERVER_KEY=${PG_SERVER_KEY}.lega
+    cp "${PG_SERVER_CERT}" "${PG_SERVER_CERT}.lega"
+    PG_SERVER_CERT=${PG_SERVER_CERT}.lega
     chown postgres:postgres "${PG_SERVER_KEY}" "${PG_SERVER_CERT}"
     chmod 600 "${PG_SERVER_KEY}"
 


### PR DESCRIPTION
...by copying them to new locations.
This allows `chown` and `chmod` to take effect, without fragile bash trickery.

Similar method to [what RabbitMQ does in its entrypoint](https://github.com/docker-library/rabbitmq/blob/7289bc5e9d408054876a918b20e3a93e0618a45a/3.7/alpine/docker-entrypoint.sh#L93-L101)