### PR TITLE
Table for session keys checksums

### DIFF
--- a/initdb.d/main.sql
+++ b/initdb.d/main.sql
@@ -116,11 +116,26 @@ CREATE TRIGGER main_updated AFTER UPDATE ON local_ega.main FOR EACH ROW EXECUTE 
 -- ##################################################
 -- To keep track of already used session keys,
 -- we record their checksum
-CREATE TABLE local_ega.session_key_checksums (
+CREATE TABLE local_ega.session_key_checksums_sha256 (
        session_key_checksum      VARCHAR(128) NOT NULL, PRIMARY KEY(session_key_checksum), UNIQUE (session_key_checksum),
        session_key_checksum_type checksum_algorithm,
        file_id                   INTEGER NOT NULL REFERENCES local_ega.main(id) ON DELETE CASCADE
 );
+
+
+-- Returns if the session key checksums are already found in the database
+CREATE FUNCTION check_session_keys_checksums_sha256(checksums text[]) --local_ega.session_key_checksums.session_key_checksum%TYPE []
+    RETURNS boolean AS $check_session_keys_checksums_sha256$
+    #variable_conflict use_column
+    BEGIN
+	RETURN EXISTS(SELECT 1
+                      FROM local_ega.session_key_checksums_sha256 sk 
+	              INNER JOIN local_ega.files f
+		      ON f.id = sk.file_id 
+		      WHERE (f.status <> 'ERROR' AND f.status <> 'DISABLED') AND -- no data-race on those values
+		      	    sk.session_key_checksum = ANY(checksums));
+    END;
+$check_session_keys_checksums_sha256$ LANGUAGE plpgsql;
 
 
 -- ##################################################
@@ -137,6 +152,7 @@ CREATE TABLE local_ega.main_errors (
 	occured_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
 );
 
+
 -- ##################################################
 --         Data-In View
 -- ##################################################
@@ -152,13 +168,11 @@ SELECT id,
        archive_file_reference                     AS archive_path,
        archive_file_type                          AS archive_type,
        archive_file_size                          AS archive_filesize,
-       archive_file_checksum                      AS unencrypted_checksum,
-       archive_file_checksum_type                 AS unencrypted_checksum_type,
+       archive_file_checksum                      AS archive_file_checksum,
+       archive_file_checksum_type                 AS archive_file_checksum_type,
        stable_id,
        header,  -- Crypt4gh specific
        version,
-       session_key_checksum,
-       session_key_checksum_type,
        created_at,
        last_modified
 FROM local_ega.main;
@@ -194,8 +208,8 @@ $insert_file$ LANGUAGE plpgsql;
 -- Flag as READY, and mark older ingestion as deprecated (to clean up)
 CREATE FUNCTION finalize_file(inpath        local_ega.files.inbox_path%TYPE,
 			      eid           local_ega.files.elixir_id%TYPE,
-			      checksum      local_ega.files.unencrypted_checksum%TYPE,
-			      checksum_type VARCHAR, -- local_ega.files.unencrypted_checksum_type%TYPE,
+			      checksum      local_ega.files.archive_file_checksum%TYPE,
+			      checksum_type VARCHAR, -- local_ega.files.archive_file_checksum_type%TYPE,
 			      sid           local_ega.files.stable_id%TYPE)
     RETURNS void AS $finalize_file$
     #variable_conflict use_column
@@ -203,8 +217,8 @@ CREATE FUNCTION finalize_file(inpath        local_ega.files.inbox_path%TYPE,
 	-- -- Check if in proper state
 	-- IF EXISTS(SELECT id
 	--    	  FROM local_ega.main
-	-- 	  WHERE unencrypted_checksum = checksum AND
-	-- 	  	unencrypted_checksum_type = upper(checksum_type)::local_ega.checksum_algorithm AND
+	-- 	  WHERE archive_file_checksum = checksum AND
+	-- 	  	archive_file_checksum_type = upper(checksum_type)::local_ega.checksum_algorithm AND
 	-- 		elixir_id = eid AND
 	-- 		inbox_path = inpath AND
 	-- 		status <> 'COMPLETED')
@@ -215,8 +229,8 @@ CREATE FUNCTION finalize_file(inpath        local_ega.files.inbox_path%TYPE,
 	UPDATE local_ega.files
 	SET status = 'READY',
 	    stable_id = sid
-	WHERE unencrypted_checksum = checksum AND
-	      unencrypted_checksum_type = upper(checksum_type)::local_ega.checksum_algorithm AND
+	WHERE archive_file_checksum = checksum AND
+	      archive_file_checksum_type = upper(checksum_type)::local_ega.checksum_algorithm AND
 	      elixir_id = eid AND
 	      inbox_path = inpath AND
 	      status = 'COMPLETED';
@@ -232,18 +246,6 @@ BEGIN
 END;
 $is_disabled$ LANGUAGE plpgsql;
 
--- Returns if the session key checksum is already found in the database
-CREATE FUNCTION check_session_key_checksum(checksum      local_ega.files.session_key_checksum%TYPE,
-       		      			   checksum_type VARCHAR) -- local_ega.files.session_key_checksum_type%TYPE)
-    RETURNS boolean AS $check_session_key_checksum$
-    #variable_conflict use_column
-    BEGIN
-	RETURN EXISTS(SELECT 1 FROM local_ega.files
-		      WHERE session_key_checksum = checksum AND
-		      	    session_key_checksum_type = upper(checksum_type)::local_ega.checksum_algorithm AND
-			    (status <> 'ERROR' OR status <> 'DISABLED'));
-    END;
-$check_session_key_checksum$ LANGUAGE plpgsql;
 
 -- Just showing the current/active errors
 CREATE VIEW local_ega.errors AS
@@ -293,8 +295,8 @@ SELECT id                        AS file_id
      , archive_file_reference      AS archive_path
      , archive_file_type           AS archive_type
      , archive_file_size           AS archive_filesize
-     , archive_file_checksum       AS unencrypted_checksum
-     , archive_file_checksum_type  AS unencrypted_checksum_type
+     , archive_file_checksum       AS archive_file_checksum
+     , archive_file_checksum_type  AS archive_file_checksum_type
      , header                    AS header
      , version                   AS version
 FROM local_ega.main


### PR DESCRIPTION
Recording the checksums of the session keys allows us to make sure only one key is used per file in the Vault.

When the `verify` service starts decrypting the file, it makes a connection to the database and checks if the session keys are not (likely) already present, by comparing their sha256 checksums. It returns a boolean.


